### PR TITLE
added the ability of reversing NumberAndSecondaryStat widgets

### DIFF
--- a/src/CarlosIO/Geckoboard/Widgets/NumberAndSecondaryStat.php
+++ b/src/CarlosIO/Geckoboard/Widgets/NumberAndSecondaryStat.php
@@ -9,6 +9,9 @@ use CarlosIO\Geckoboard\Widgets\Widget;
  */
 class NumberAndSecondaryStat extends Widget
 {
+    const TYPE_REGULAR = null;
+    const TYPE_REVERSE = 'reverse';
+
     /**
      * @var null Main value
      */
@@ -21,6 +24,10 @@ class NumberAndSecondaryStat extends Widget
      * @var null Main value prefix
      */
     private $mainPrefix = null;
+    /**
+     * @var null Main value prefix
+     */
+    private $type = null;
 
     /**
      * Set data main prefix (€, $, etc.)
@@ -92,13 +99,33 @@ class NumberAndSecondaryStat extends Widget
     }
 
     /**
+     * @param string|null $prefix
+     */
+    public function setType($prefix)
+    {
+        $this->type = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+
+
+    /**
      * {@inheritdoc}
      */
     public function getData()
     {
         $data = array(
             'text' => '',
-            'value' => (int) $this->getMainValue()
+            'value' => (int) $this->getMainValue(),
         );
 
         $prefix = $this->getMainPrefix();
@@ -107,7 +134,8 @@ class NumberAndSecondaryStat extends Widget
         }
 
         $result = array(
-            'item' => array($data)
+            'item' => array($data),
+            'type' => $this->getType(),
         );
 
         $secondaryValue = $this->getSecondaryValue();

--- a/tests/CarlosIO/Geckoboard/Widgets/NumberAndSecondaryStatTest.php
+++ b/tests/CarlosIO/Geckoboard/Widgets/NumberAndSecondaryStatTest.php
@@ -10,7 +10,7 @@ class NumberAndSecondaryStatTest extends \PHPUnit_Framework_TestCase
     {
         $widget = new NumberAndSecondaryStat();
         $json = json_encode($widget->getData());
-        $this->assertEquals('{"item":[{"text":"","value":0}]}', $json);
+        $this->assertEquals('{"item":[{"text":"","value":0}],"type":null}', $json);
     }
 
     public function testGetAndSetWidgetId()
@@ -27,7 +27,7 @@ class NumberAndSecondaryStatTest extends \PHPUnit_Framework_TestCase
         $widget = new NumberAndSecondaryStat();
         $widget->setMainValue(35);
         $json = json_encode($widget->getData());
-        $this->assertEquals('{"item":[{"text":"","value":35}]}', $json);
+        $this->assertEquals('{"item":[{"text":"","value":35}],"type":null}', $json);
     }
 
     public function testJsonForFullData()
@@ -37,6 +37,15 @@ class NumberAndSecondaryStatTest extends \PHPUnit_Framework_TestCase
         $widget->setSecondaryValue(50);
         $widget->setMainPrefix('EUR');
         $json = json_encode($widget->getData());
-        $this->assertEquals('{"item":[{"text":"","value":100,"prefix":"EUR"},{"text":"","value":50}]}', $json);
+        $this->assertEquals('{"item":[{"text":"","value":100,"prefix":"EUR"},{"text":"","value":50}],"type":null}', $json);
+    }
+
+    public function testSettingADifferentType()
+    {
+        $widget = new NumberAndSecondaryStat();
+        $widget->setMainValue(100);
+        $widget->setType(NumberAndSecondaryStat::TYPE_REVERSE);
+        $json = json_encode($widget->getData());
+        $this->assertEquals('{"item":[{"text":"","value":100}],"type":"reverse"}', $json);
     }
 }


### PR DESCRIPTION
I am using this widget and I need to [reverse it](http://www.geckoboard.com/developers/custom-widgets/widget-types/number-and-optional-secondary-stat), which means that if the secondary value is lower, the widget will become red (think of application performances, where today its 100ms and yesterday was 50ms, the widget would show it as an improvement :) ). 
