### PR TITLE
Add missing parameter "absolute" and "text" to NumberAndSecondaryStat

### DIFF
--- a/src/CarlosIO/Geckoboard/Tests/Widgets/NumberAndSecondaryStatTest.php
+++ b/src/CarlosIO/Geckoboard/Tests/Widgets/NumberAndSecondaryStatTest.php
@@ -48,4 +48,37 @@ class NumberAndSecondaryStatTest extends \PHPUnit_Framework_TestCase
         $json = json_encode($widget->getData());
         $this->assertEquals('{"item":[{"text":"","value":100}],"type":"reverse"}', $json);
     }
+
+    public function testSetGetMainText()
+    {
+        $text = 'text';
+        $widget = new NumberAndSecondaryStat();
+        $widget->setMainText($text);
+
+        $this->assertSame($text, $widget->getMainText());
+        $data = $widget->getData();
+        $this->assertSame($text, $data['item'][0]['text']);
+    }
+
+    public function testSetGetSecondaryText()
+    {
+        $text = 'text';
+        $widget = new NumberAndSecondaryStat();
+        $widget->setSecondaryValue(1);
+        $widget->setSecondaryText($text);
+
+        $this->assertSame($text, $widget->getSecondaryText());
+        $data = $widget->getData();
+        $this->assertSame($text, $data['item'][1]['text']);
+    }
+
+    public function testAbsolute()
+    {
+        $widget = new NumberAndSecondaryStat();
+        $widget->setAbsolute(true);
+
+        $data = $widget->getData();
+
+        $this->assertTrue($data['absolute']);
+    }
 }

--- a/src/CarlosIO/Geckoboard/Widgets/NumberAndSecondaryStat.php
+++ b/src/CarlosIO/Geckoboard/Widgets/NumberAndSecondaryStat.php
@@ -31,6 +31,21 @@ class NumberAndSecondaryStat extends Widget
     private $type = null;
 
     /**
+     * @var string
+     */
+    private $mainText = '';
+
+    /**
+     * @var string
+     */
+    private $secondaryText = '';
+
+    /**
+     * @var boolean
+     */
+    private $absolute = false;
+
+    /**
      * Set data main prefix (€, $, etc.)
      *
      * @param string $mainPrefix
@@ -77,6 +92,30 @@ class NumberAndSecondaryStat extends Widget
     }
 
     /**
+     * Set the primary text value. (Visible if widget is 2x2
+     * or 1x1 without a secondary value)
+     *
+     * @param string $mainText The text body
+     *
+     * @return NumberAndSecondaryStat
+     */
+    public function setMainText($mainText)
+    {
+        $this->mainText = $mainText;
+        return $this;
+    }
+
+    /**
+     * Return the main text body.
+     *
+     * @return string
+     */
+    public function getMainText()
+    {
+        return $this->mainText;
+    }
+
+    /**
      * Set secondary value
      *
      * @param int $secondaryValue
@@ -100,6 +139,29 @@ class NumberAndSecondaryStat extends Widget
     }
 
     /**
+     * Set the secondary text value. (Visible if widget is 2x2)
+     *
+     * @param string $secondaryText The text body
+     *
+     * @return NumberAndSecondaryStat
+     */
+    public function setSecondaryText($secondaryText)
+    {
+        $this->secondaryText = $secondaryText;
+        return $this;
+    }
+
+    /**
+     * Return the secondary text body.
+     *
+     * @return string
+     */
+    public function getSecondaryText()
+    {
+        return $this->secondaryText;
+    }
+
+    /**
      * @param string|null $prefix
      */
     public function setType($prefix)
@@ -117,7 +179,18 @@ class NumberAndSecondaryStat extends Widget
         return $this->type;
     }
 
-
+    /**
+     * Mark this widget as absolute.
+     *
+     * @param boolean $absolute The absolute value
+     *
+     * @return NumberAndSecondaryStat
+     */
+    public function setAbsolute($absolute)
+    {
+        $this->absolute = $absolute;
+        return $this;
+    }
 
     /**
      * {@inheritdoc}
@@ -125,8 +198,8 @@ class NumberAndSecondaryStat extends Widget
     public function getData()
     {
         $data = array(
-            'text' => '',
-            'value' => (int) $this->getMainValue(),
+            'text' => $this->mainText,
+            'value' => (float) $this->getMainValue(),
         );
 
         $prefix = $this->getMainPrefix();
@@ -139,11 +212,15 @@ class NumberAndSecondaryStat extends Widget
             'type' => $this->getType(),
         );
 
+        if ($this->absolute) {
+            $result['absolute'] = $this->absolute;
+        }
+
         $secondaryValue = $this->getSecondaryValue();
         if (null !== $secondaryValue) {
             $result['item'][] = array(
-                'text' => '',
-                'value' => (int) $secondaryValue
+                'text' => $this->secondaryText,
+                'value' => (float) $secondaryValue
             );
         }
 


### PR DESCRIPTION
Geckoboard allows a widget to be marked as "absolute" in order to display the difference between two numbers. It also allows the user to specify "text" values if the widget is 2x2 and the values can be formatted as float and not just integers.
