### PR TITLE
Label should not be required for the ItemList widget.

### DIFF
--- a/src/CarlosIO/Geckoboard/Widgets/ItemList.php
+++ b/src/CarlosIO/Geckoboard/Widgets/ItemList.php
@@ -9,11 +9,15 @@ class ItemList extends Widget
 {
     protected $items = array();
 
-    public function addItem(Title $title, Label $label, $description)
+    public function addItem(Title $title, $label, $description)
     {
         $count = count($this->items);
         $this->items[$count]['title'] = $title->toArray();
-        $this->items[$count]['label'] = $label->toArray();
+
+        if ($label instanceof Label) {
+            $this->items[$count]['label'] = $label->toArray();
+        }
+
         $this->items[$count]['description'] = $description;
     }
 


### PR DESCRIPTION
ItemWidget Label fields have been made mandatory in the code, but they are optional on Geckoboard.
