### PR TITLE
Add setGuzzleConfig to allow setting timeout

### DIFF
--- a/src/CarlosIO/Geckoboard/Client.php
+++ b/src/CarlosIO/Geckoboard/Client.php
@@ -33,6 +33,16 @@ class Client
     }
 
     /**
+     * @param array|\Guzzle\Common\Collection $config
+     * @return Client $this
+     */
+    public function setGuzzleConfig($config)
+    {
+        $this->client->setConfig($config);
+        return $this;
+    }
+
+    /**
      * Set Geckoboard API key
      *
      * @param $apiKey


### PR DESCRIPTION
We were having issues where our `$geckoboardClient->push($widget);` call would fail, but without a timeout would sit for a very long time. This PR allows setting the timeouts on Guzzle which has solved our issue.