### PR TITLE
Added support for display main values as time duration

### DIFF
--- a/src/CarlosIO/Geckoboard/Tests/Widgets/NumberAndSecondaryStatTest.php
+++ b/src/CarlosIO/Geckoboard/Tests/Widgets/NumberAndSecondaryStatTest.php
@@ -81,4 +81,14 @@ class NumberAndSecondaryStatTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($data['absolute']);
     }
+
+    public function testSetDisplayAsTimeDuration()
+    {
+        $widget = new NumberAndSecondaryStat();
+        $widget->setDisplayAsTimeDuration(true);
+
+        $data = $widget->getData();
+
+        $this->assertSame('time_duration', $data['item'][0]['type']);
+    }
 }

--- a/src/CarlosIO/Geckoboard/Widgets/NumberAndSecondaryStat.php
+++ b/src/CarlosIO/Geckoboard/Widgets/NumberAndSecondaryStat.php
@@ -43,6 +43,11 @@ class NumberAndSecondaryStat extends Widget
     private $absolute = false;
 
     /**
+     * @var boolean
+     */
+    private $displayAsTimeDuration = false;
+
+    /**
      * Set data main prefix (€, $, etc.).
      *
      * @param string $mainPrefix
@@ -198,6 +203,20 @@ class NumberAndSecondaryStat extends Widget
     }
 
     /**
+     * Mark this widget for display main value as time duration (from milliseconds).
+     *
+     * @param boolean $displayAsTimeDuration
+     *
+     * @return NumberAndSecondaryStat
+     */
+    public function setDisplayAsTimeDuration($displayAsTimeDuration)
+    {
+        $this->displayAsTimeDuration = $displayAsTimeDuration;
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getData()
@@ -210,6 +229,10 @@ class NumberAndSecondaryStat extends Widget
         $prefix = $this->getMainPrefix();
         if (null !== $prefix) {
             $data['prefix'] = (string) $prefix;
+        }
+
+        if ($this->displayAsTimeDuration) {
+            $data['type'] = 'time_duration';
         }
 
         $result = array(


### PR DESCRIPTION
The Geckoboard API (https://developer.geckoboard.com/#parameters-22) describes a `type` parameter inside the main item data as following:

> As well as a number, you can also display other number-like metrics. Possible values are time_duration and text.
> 
> time_duration displays a time duration instead of a number for both the primary and the secondary values, by interpreting the numeric value as the number of milliseconds in the time period.
> 
> For example, 565000 (ms) would be displayed as 9m 25s (9 minutes 25 seconds).
> 
> text displays the primary metric as text instead of a number. This is useful, for example, when you would like to display a value with a custom unit.

In this pull request I added support for display main value as time duration.
